### PR TITLE
Add variable for Ubuntu22 Java package

### DIFF
--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -1,0 +1,6 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-11-jdk
+_java_packages:
+  - openjdk-11-jdk


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature for Ubuntu 22

- **What is the current behavior?** (You can also link to an open issue here)
Ansible failing to install

```
fatal: [gh-runner001]: FAILED! => {"ansible_facts": {}, "ansible_included_var_files": [], "changed": false, "message": "Could not find or access 'Ubuntu-22.yml'
```

- **What is the new behavior (if this is a feature change)?**
Working for Ubuntu 22

- **Other information**:
